### PR TITLE
Ubuntu 16.04 - /proc/sys/fs/binfmt_misc/register: No such file or directory 

### DIFF
--- a/oven
+++ b/oven
@@ -265,6 +265,7 @@ function prepare_chroot() {
 
     cp "$opt_qemu_src" "${opt_mount_point}/${opt_qemu_dst}"
     if ! ls /proc/sys/fs/binfmt_misc/qemu-arm &> /dev/null ; then
+        mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc  
         log "INFO" "Installing binfmt configuration for ARM binaries"
         echo -e "$arm_binfmt" > /proc/sys/fs/binfmt_misc/register
     fi

--- a/oven
+++ b/oven
@@ -223,9 +223,12 @@ function mount_image() {
     mount --bind /sys "${opt_mount_point}/sys"
     mount -t proc none "${opt_mount_point}/proc"
     
-    # Mount binfmt_misc seems to be needed for ubuntu 16.04+ at least
-    log "INFO" "Mouting binfmt_misc"
-    mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc  
+    if [ ! -e /proc/sys/fs/binfmt_misc/register ]; then
+        # Mount binfmt_misc seems to be needed for ubuntu 16.04+ at least    
+        log "INFO" "Mouting binfmt_misc"
+        mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc    
+    fi
+    
 }
 
 # umount_image image - Unmount disk image
@@ -271,7 +274,7 @@ function prepare_chroot() {
     arm_binfmt+='/usr/bin/qemu-arm-static:'
 
     cp "$opt_qemu_src" "${opt_mount_point}/${opt_qemu_dst}"
-    if ! ls /proc/sys/fs/binfmt_misc/qemu-arm &> /dev/null ; then       
+    if ! ls /proc/sys/fs/binfmt_misc/qemu-arm &> /dev/null ; then
         log "INFO" "Installing binfmt configuration for ARM binaries"
         echo -e "$arm_binfmt" > /proc/sys/fs/binfmt_misc/register
     fi

--- a/oven
+++ b/oven
@@ -222,6 +222,10 @@ function mount_image() {
     mount --bind /dev "${opt_mount_point}/dev"
     mount --bind /sys "${opt_mount_point}/sys"
     mount -t proc none "${opt_mount_point}/proc"
+    
+    # Mount binfmt_misc seems to be needed for ubuntu 16.04+ at least
+    log "INFO" "Mouting binfmt_misc"
+    mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc  
 }
 
 # umount_image image - Unmount disk image
@@ -246,6 +250,9 @@ function umount_image() {
 
     log "INFO" "Deleting device mapper for ${image}"
     kpartx -dsv "$image" > /dev/null
+    
+    log "INFO" "Unmounting binfmt_misc"
+    umount binfmt_misc
 }
 
 # check_privileges - Check if we have root privilege
@@ -264,8 +271,7 @@ function prepare_chroot() {
     arm_binfmt+='/usr/bin/qemu-arm-static:'
 
     cp "$opt_qemu_src" "${opt_mount_point}/${opt_qemu_dst}"
-    if ! ls /proc/sys/fs/binfmt_misc/qemu-arm &> /dev/null ; then
-        mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc  
+    if ! ls /proc/sys/fs/binfmt_misc/qemu-arm &> /dev/null ; then       
         log "INFO" "Installing binfmt configuration for ARM binaries"
         echo -e "$arm_binfmt" > /proc/sys/fs/binfmt_misc/register
     fi


### PR DESCRIPTION
Using a clean ubuntu:16.04 docker image and raspbian-stretch it would appear that binfmt_misc is broken. Issuing a manual mount for binfmt_misc corrects the issue. 

You can use the below .gitlab-ci.yml (gitlab runner config) to verify.

```
image: ubuntu:16.04

cache:
  paths:
  - images
  
before_script:
    - pwd
    - ls -all
    - apt-get update -qq && apt-get install -y -qq systemd wget curl unzip kpartx parted gnu-fdisk dosfstools systemd-container qemu-user-static binfmt-support
    - curl -O https://raw.githubusercontent.com/keichi/pi-oven/master/oven
    - install oven /usr/bin
    - curl -O https://raw.githubusercontent.com/keichi/pi-oven/master/qemu-arm-static
    - install qemu-arm-static /usr/bin
    - unzip -n images/2017-09-07-raspbian-stretch-lite.zip -d images

job1:
  script: oven -r 2000 -s installer/stock_raspbian/scripts/test.sh images/2017-09-07-raspbian-stretch-lite.img images/2017-09-07-raspbian-stretch-lite-$CI_JOB_ID-baked.img  

```


Notice the error below: **/usr/bin/oven: line 269: /proc/sys/fs/binfmt_misc/register: No such file or directory**
```
$ install qemu-arm-static /usr/bin
$ unzip -n images/2017-09-07-raspbian-stretch-lite.zip -d images
Archive:  images/2017-09-07-raspbian-stretch-lite.zip
$ oven -r 2000 -s installer/stock_raspbian/scripts/test.sh images/2017-09-07-raspbian-stretch-lite.img images/2017-09-07-raspbian-stretch-lite-$CI_JOB_ID-baked.img
[INFO] Copying disk image file images/2017-09-07-raspbian-stretch-lite.img to images/2017-09-07-raspbian-stretch-lite-40211765-baked.img
[INFO] Resizing disk image file /builds/kfowlks/pi-bell/images/2017-09-07-raspbian-stretch-lite-40211765-baked.img to 2000MB
[INFO] Extending disk image file
[INFO] Extending root partition
[INFO] Creating device mapper for /builds/kfowlks/pi-bell/images/2017-09-07-raspbian-stretch-lite-40211765-baked.img
[INFO] Mouting /dev/mapper/loop0p2 to /mnt/oven
[INFO] Mouting /dev/mapper/loop0p1 to /mnt/oven/boot
[INFO] Mouting devfs, sysfs and procfs
[INFO] Installing binfmt configuration for ARM binaries
/usr/bin/oven: line 269: /proc/sys/fs/binfmt_misc/register: No such file or directory
[INFO] Using qemu-arm-static in /usr/bin/qemu-arm-static
chroot: failed to run command '/bin/sed': Exec format error
[INFO] Script provisioning: executing provisioning script /builds/kfowlks/pi-bell/installer/stock_raspbian/scripts/test.sh
chroot: failed to run command '/bin/bash': Exec format error
[ERROR] Provisioning script returned error
chroot: failed to run command '/bin/sed': Exec format error
[INFO] Unmouting devfs, sysfs and procfs
[INFO] Unmounting /mnt/oven/boot
[INFO] Unmounting /mnt/oven
[INFO] Deleting device mapper for /builds/kfowlks/pi-bell/images/2017-09-07-raspbian-stretch-lite-40211765-baked.img
Creating cache default...
images: found 8 matching files                     
Created cache
Job succeeded
```

So adding the below

**mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc**  

Seems to correct the issue. 
